### PR TITLE
Finish test webdriver session

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -131,11 +131,15 @@ public abstract class SeleniumTestHandler implements ITestListener, ISuiteListen
      * Check if webdriver session can be created without errors.
      */
     private void checkWebDriverSessionCreation() {
-        try (SeleniumWebDriver seleniumWebDriver
-                     = new SeleniumWebDriver(browser,
-                                             webDriverPort,
-                                             gridMode,
-                                             webDriverVersion)) {
+        SeleniumWebDriver seleniumWebDriver = null;
+        try {
+            seleniumWebDriver = new SeleniumWebDriver(browser,
+                                                      webDriverPort,
+                                                      gridMode,
+                                                      webDriverVersion);
+        } finally {
+            Optional.ofNullable(seleniumWebDriver)
+                    .ifPresent(SeleniumWebDriver::quit);  // finish webdriver session
         }
     }
 


### PR DESCRIPTION
### What does this PR do?
Finish test webdriver session of selenium tests to free slot in selenium grid:
```
curl -H "Content-Type: application/json; charset=UTF-8" -H "Accept: application/json" http://localhost:4444/grid/api/hub | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   414  100   414    0     0  52819      0 --:--:-- --:--:-- --:--:-- 59142
{
  "slotCounts": {
    "total": 2,
    "free": 2
  },
  "newSessionRequestCount": 0,
  "maxSession": 1,
  "host": "172.18.0.2",
  "custom": {},
  "cleanUpCycle": 5000,
  "throwOnCapabilityNotPresent": true,
  "newSessionWaitTimeout": -1,
  "capabilityMatcher": "org.openqa.grid.internal.utils.DefaultCapabilityMatcher",
  "success": true,
  "servlets": [],
  "withoutServlets": [],
  "browserTimeout": 900,
  "debug": false,
  "jettyMaxThreads": -1,
  "port": 4444,
  "role": "hub",
  "timeout": 900
}
```
@tolusha: please, accept this request.