### PR TITLE
Fix headers of java files

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) [2012] - [2017] Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckDisplayingArtifactIdTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckDisplayingArtifactIdTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) [2012] - [2017] Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
### What does this PR do?
This request fixes build error:
```
[WARNING] Missing header in: /home/ndp/projects/dmytro-ndp/che/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
[WARNING] Missing header in: /home/ndp/projects/dmytro-ndp/che/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckDisplayingArtifactIdTest.java
```