### PR TITLE
Fix copyright headers of test resource files; turn on check on header

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2016 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 
 # we need to have at least 2 threads for tests which start several WebDriver instances at once, for example, tests of File Watcher

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -128,14 +128,6 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>**/resources/**/projects/**</exclude>
-                        <exclude>**/resources/**/templates/**</exclude>
-                        <exclude>**/resources/**/*.zip</exclude>
-                        <exclude>**/resources/**/org/eclipse/che/selenium/**</exclude>
-                    </excludes>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/selenium/che-selenium-test/selenium-tests.sh
+++ b/selenium/che-selenium-test/selenium-tests.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2016 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 export CUR_DIR=$(cd "$(dirname "$0")"; pwd)
 export CALLER=$(basename $0)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/FormatterTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/FormatterTest.java
@@ -37,14 +37,14 @@ import java.nio.file.Paths;
 public class FormatterTest {
     private static final String PROJECT_NAME   = NameGenerator.generate(FormatterTest.class.getSimpleName(), 4);
     private static final String FORMATTED_TEXT = "/*******************************************************************************\n" +
-                                                 " * Copyright (c) 2012-2017 Codenvy, S.A.\n" +
+                                                 " * Copyright (c) 2012-2017 Red Hat, Inc.\n" +
                                                  " * All rights reserved. This program and the accompanying materials\n" +
                                                  " * are made available under the terms of the Eclipse Public License v1.0\n" +
                                                  " * which accompanies this distribution, and is available at\n" +
                                                  " * http://www.eclipse.org/legal/epl-v10.html\n" +
                                                  " *\n" +
                                                  " * Contributors:\n" +
-                                                 " *   Codenvy, S.A. - initial API and implementation\n" +
+                                                 " *   Red Hat, Inc. - initial API and implementation\n" +
                                                  " *******************************************************************************/\n" +
                                                  "package org.eclipse.qa.examples;\n" +
                                                  "\n" +

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/editor/split-editor-restore-exp-text.txt
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/editor/split-editor-restore-exp-text.txt
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/miscellaneous/file.js
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/miscellaneous/file.js
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
 var express = require('express');
 var app = express();

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/miscellaneous/file.php
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/miscellaneous/file.php
@@ -1,15 +1,14 @@
 <?php
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
-
 echo "Hello World!"
 
 ?>

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/miscellaneous/maven-project-pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/miscellaneous/maven-project-pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/preferences/embed-code
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/preferences/embed-code
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test0;
 /**

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test0/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test0/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test0;
 /**

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test1;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test1/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test1/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test1;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test10/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test10/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test10;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test10/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test10/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test10;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test2;
 interface A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test2/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test2/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test2;
 interface A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test24/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test24/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test24;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test24/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test24/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test24;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test25/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test25/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test25;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test25/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test25/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test25;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test26/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test26/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test26;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test26/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test26/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test26;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test28/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test28/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test28;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test28/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test28/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test28;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3;
 /**

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test3/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test3/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3;
 /**

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test31/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test31/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test31;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test31/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test31/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test31;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test32/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test32/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test32;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test32/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test32/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test32;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test33/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test33/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test33;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test33/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test33/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test33;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test36;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/in/messages.properties
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/in/messages.properties
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2012-2017 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 
 f=a

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test36;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/out/messages.properties
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test36/out/messages.properties
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2012-2017 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 
 g=a

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test4/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test4/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test4/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test4/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test5/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test5/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test6/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test6/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test6;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test6/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test6/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test6;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test7/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test7/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test7/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test7/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test8/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test8/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test8/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test8/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test9/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test9/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test9;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test9/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/test9/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test9;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail10/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail10/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail10;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail14/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail14/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail14;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail3;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail7/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/none-private/testfail7/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test0/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test0/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test1;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test1/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test1/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test1;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test10/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test10/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test10;
 import java.util.List;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test10/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test10/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test10;
 import java.util.List;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test11/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test11/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test11;
 import Test.Element;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test11/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test11/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test11;
 import Test.Element;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test12/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test12/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test12;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test12/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test12/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test12;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update
 package test2;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test2/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test2/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update
 package test2;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test3/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test3/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test4/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test4/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test4/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test4/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test5;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test5/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test5/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test5;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test6/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test6/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test6;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test6/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test6/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test6;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test7/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test7/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test7/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test7/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test8/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test8/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test8;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test8/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test8/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test8;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test9/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test9/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test9;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test9/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/test9/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test9;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail4/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail4/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail6/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail6/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail6;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail7/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/fields/private/testfail7/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail7;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test0;
 //renaming I.m to k

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test0/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test0/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test0;
 //renaming I.m to k

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test12/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test12/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test12;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test12/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test12/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test12;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test20/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test20/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test20;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test20/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test20/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test20;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test31/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test31/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test31;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test31/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test31/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test31;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test44/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test44/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test44;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test44/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/test44/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test44;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testAnnotation1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testAnnotation1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testAnnotation1;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testAnnotation1/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testAnnotation1/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testAnnotation1;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail12/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail12/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testFail12;
 //can't rename m to k - defined in subclass

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail12/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail12/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test20;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail33/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail33/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testFail33;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail33/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail33/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test20;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testFail5;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail5/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testFail5/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testFail5;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testGenerics01/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testGenerics01/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testGenerics01;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testGenerics01/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/interface/testGenerics01/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testGenerics01;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test0/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test0/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test1/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test1/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test10/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test10/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test10;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test10/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test10/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test10;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test11/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test11/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test11;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test11/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test11/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test11;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test12/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test12/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test12;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test12/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test12/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test12;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test2;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test2/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test2/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test2;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test23/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test23/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test23;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test23/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test23/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test23;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test3/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test3/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test4/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test4/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test4/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test4/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test5/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/test5/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testAnon0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testAnon0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.testAnon0;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testAnon0/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testAnon0/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.testAnon0;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testFail5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testFail5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.testFail5;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testFail5/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/private/testFail5/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test2; 
  

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test0/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test0/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test1/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test1/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test11;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/in/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/in/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test11;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test11/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test11;
 import renameStaticMethods.test11.A;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test2;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test2/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test2/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test2;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test8/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test8/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test8/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/test8/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/testFail5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/testFail5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.testFail5;
 //can't rename native methods

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/testFail5/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/static/testFail5/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test1;
 abstract class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test1/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test1/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test1;
 abstract class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test11/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test11/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test11;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test11/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test11/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test11;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test25/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test25/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test25;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test25/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/test25/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test25;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testEnum2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testEnum2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testEnum2;
 class Generic<E> {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testEnum2/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testEnum2/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testEnum2;
 class Generic<E> {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testFail35/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testFail35/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testFail35;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testFail35/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testFail35/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testEnum2;
 class Generic<E> {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testGeneric2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testGeneric2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testGeneric2;
 class A<E>{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testGeneric2/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testGeneric2/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testGeneric2;
 class A<E>{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testVarArgs1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testVarArgs1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testVarArgs1;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testVarArgs1/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/methods/virtual/testVarArgs1/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testVarArgs1;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 /**

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test0/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test0/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package p1;
 /**

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 class A1{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test1/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test1/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package p1;
 class A1{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 public class A2 {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/in/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/in/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.fred2;
 import r.*;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package p1;
 public class A2 {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test2/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.fred2;
 import p1.A2;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.r;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/in/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/in/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.fred3;
 import r.r.*;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package p1;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test3/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.fred3;
 import p1.A3;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test4/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test4/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.r.r;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test4/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test4/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package p1;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 public class A5 {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test5/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test5/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.r;
 public class A5 {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test6/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test6/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 // no update of textual match to r and "r"
 package r;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test6/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test6/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 // no update of textual match to r and "r"
 package p1;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test7/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test7/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test7/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test7/out/A.java
@@ -1,14 +1,13 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
-
 
 public class A7 {
     A7 a;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test8/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test8/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package java.lang.reflect;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test8/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test8/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package p1;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test9/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test9/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test9/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/test9/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package p1;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/testfail17/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/testfail17/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update
 package r;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/testfail17/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/move/testfail17/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update
 package p1;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j
 package test0;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test0/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test0/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j
 package test0;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test12/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test12/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to j
 package test12;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test12/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test12/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to j
 package test12;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test15/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test15/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j, i
 package test15;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test15/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test15/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j, i
 package test15;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test18/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test18/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test18;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test18/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test18/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test18;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test21/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test21/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test21;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test21/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test21/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test21;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test25/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test25/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test25;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test25/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test25/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test25;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test28/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test28/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test28;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test28/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test28/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test28;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j, j1
 package test3;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test3/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test3/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j, j1
 package test3;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test31/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test31/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to kk, j
 package test31;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test31/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test31/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to kk, j
 package test31;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test33/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test33/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to b, no ref update
 package test33;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test33/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test33/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to b, no ref update
 package test33;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test36/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test36/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test36;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test36/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test36/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test36;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test6/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test6/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to k
 package test6;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test6/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test6/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to k
 package test6;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test9/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test9/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to j
 package test9;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test9/out/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/test9/out/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to j
 package test9;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail11/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail11/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j, j
 package testfail11;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail14/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail14/in/A.java
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail17/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail17/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j
 package testfail17;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to i, i
 package testfail2;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail20/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail20/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j
 package testfail20;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: i, 9
 package testfail3;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail7/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/parameters/testfail7/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j
 package testfail7;

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test0/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test0/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test0/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test0/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test1;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test1/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test1/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test1;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test2;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test2/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test2/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test2;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test3/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test3/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test3;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test3/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test3/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test3;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test4/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test4/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test4/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test4/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test4;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test5/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test5/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test5/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test5/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test5;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test6/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test6/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test6;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test6/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test6/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test6;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test7/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test7/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test7;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test7/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test7/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test7;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test8/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test8/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test8/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test8/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test8;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test9/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test9/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test9;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test9/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/test9/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test9;
 class B{

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testAnnotation1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testAnnotation1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testAnnotation1;
 @interface A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testAnnotation1/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testAnnotation1/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testAnnotation1;
 @interface B {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testEnum1;
 public enum A {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/in/p2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/in/p2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testEnum1.p2;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testEnum1;
 public enum B {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/out/p2/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testEnum1/out/p2/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testEnum1.p2;
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testGenerics2/in/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testGenerics2/in/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testGenerics2;
 class A<A> {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testGenerics2/out/B.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testGenerics2/out/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testGenerics2;
 class B<A> {

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testIllegalTypeName4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/refactor/types/testIllegalTypeName4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testIllegalTypeName4;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/.codenvy/misc.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/.codenvy/misc.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/spring/GreetingController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/spring/GreetingController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.spring;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/spring/SomeLess.less
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/spring/SomeLess.less
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8"
 ;

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/spring/SqlFile.sql
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/spring/SqlFile.sql
@@ -1,12 +1,12 @@
 --
--- Copyright (c) 2012-2017 Codenvy, S.A.
+-- Copyright (c) 2012-2017 Red Hat, Inc.
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0
 -- which accompanies this distribution, and is available at
 -- http://www.eclipse.org/legal/epl-v10.html
 --
 -- Contributors:
---   Codenvy, S.A. - initial API and implementation
+--   Red Hat, Inc. - initial API and implementation
 --
 
 Select * From Employee Where Employee.id > 100 and Employee.salary < 2000

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test1.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test1.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test2.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test2.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test3.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test3.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test4.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/java/com/codenvy/example/test/Test4.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/DefaultCss.css
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/DefaultCss.css
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8";
 h1 {

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/SomeHtml.html
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/SomeHtml.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE html>

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/someJS.js
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/someJS.js
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
 var person = {
     firstName: "John",

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/ProjectWithDifferentTypeOfFiles2/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test1;
 public class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test10/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test10/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test10;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test11/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test11/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test11;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test12/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test12/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test12;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test2;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test23/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test23/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test23;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test3;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test6/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test6/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test6;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test7;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test8/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test8/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test9/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/test9/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.test9;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/testAnon0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/testAnon0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.testAnon0;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/testFail5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethods/src/main/java/renamePrivateMethods/testFail5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renamePrivateMethods.testFail5;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test0;
 //renaming I.m to k

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test1;
 public class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test10/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test10/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test10;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test12/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test12/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test12;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test20/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test20/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test20;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test31/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test31/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test31;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test44/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/test44/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.test44;
 interface I {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testAnnotation1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testAnnotation1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testAnnotation1;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testFail12/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testFail12/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testFail12;
 //can't rename m to k - defined in subclass

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testFail33/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testFail33/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testFail33;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testFail5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testFail5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testFail5;
 interface I{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testGenerics01/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameMethodsInInterface/src/main/java/renameMethodsInInterface/testGenerics01/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameMethodsInInterface.testGenerics01;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test1/A.java
@@ -1,11 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test1;

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test11/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test11/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test11;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test11/B.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test11/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test11;
 import renameStaticMethods.test11.A;

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test2;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test3;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test8/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/test8/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/testFail5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renameStaticMethods/testFail5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameStaticMethods.testFail5;
 //can't rename native methods

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test1;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test2;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test3;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test6/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test6/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test6;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test7;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test8/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameStaticMethods/src/main/java/renametype/test8/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test0;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test1;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test2;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test3;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test6/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test6/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test6;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test7;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test8/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test8/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test9/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/test9/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.test9;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testAnnotation1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testAnnotation1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testAnnotation1;
 @interface A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testEnum1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testEnum1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testEnum1;
 public enum A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testEnum1/p2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testEnum1/p2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testEnum1.p2;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail26/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail26/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testFail26;
 import renametype.testFail26.B;

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail26/B.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail26/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testFail26;
 public interface B{}

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail35/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail35/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testFail35;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail80/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testFail80/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testFail80;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testGenerics2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testGenerics2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testGenerics2;
 class A<A> {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testIllegalTypeName4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameType/src/main/java/renametype/testIllegalTypeName4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renametype.testIllegalTypeName4;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/test1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test1;
 abstract class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/test11/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/test11/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test11;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/test25/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/test25/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.test25;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testEnum2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testEnum2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testEnum2;
 class Generic<E> {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testFail35/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testFail35/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testFail35;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testGeneric2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testGeneric2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testGeneric2;
 class A<E>{

--- a/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testVarArgs1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/RenameVirtualMethods/src/main/java/renameVirtualMethods/testVarArgs1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package renameVirtualMethods.testVarArgs1;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"

--- a/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/checkoutSpringSimple/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/file.html
+++ b/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/file.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE html>

--- a/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/src/main/java/org/eclipse/che/examples/HelloWorld.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/src/main/java/org/eclipse/che/examples/HelloWorld.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/src/test/java/com/codenvy/example/java/AppTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/console-java-with-html-file/src/test/java/com/codenvy/example/java/AppTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.java;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"

--- a/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/java/org/eclipse/qa/examples/HelloWorld.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/java/org/eclipse/qa/examples/HelloWorld.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/create-local-branch-project/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/debug-spring-project/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/java/org/eclipse/qa/examples/AdditonalClass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/java/org/eclipse/qa/examples/AdditonalClass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 import org.springframework.expression.*;

--- a/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/debugStepInto/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/java/example/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/java/example/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package example;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/java/example/InheritClass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/java/example/InheritClass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package example;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-dependency-test/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/java/che/eclipse/sample/Aclass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/java/che/eclipse/sample/Aclass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package che.eclipse.sample;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test1.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test1.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.example;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test2.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test2.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.example;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test3.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test3.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.example;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test4.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/com/example/Test4.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.example;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/LessFile.less
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/LessFile.less
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/another
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/another
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/sqlFile.sql
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/java/org/eclipse/qa/examples/sqlFile.sql
@@ -1,12 +1,12 @@
 --
--- Copyright (c) 2012-2017 Codenvy, S.A.
+-- Copyright (c) 2012-2017 Red Hat, Inc.
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0
 -- which accompanies this distribution, and is available at
 -- http://www.eclipse.org/legal/epl-v10.html
 --
 -- Contributors:
---   Codenvy, S.A. - initial API and implementation
+--   Red Hat, Inc. - initial API and implementation
 --
 
 

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/cssFile.css
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/cssFile.css
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8";
 h1 {

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/htmlFile.html
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/htmlFile.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE html>

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/jsFile.js
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/jsFile.js
@@ -1,14 +1,13 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
-
 var car = {
     model: "SomeModel",
     price : 10000,

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/test/java.org.eclipse.qa.examples/AppControlleTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/defaultSpringProjectWithDifferentTypeOfFiles/src/test/java.org.eclipse.qa.examples/AppControlleTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package  org.eclipse.qa.examples
 

--- a/selenium/che-selenium-test/src/test/resources/projects/dependency-test/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/dependency-test/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/java/helloworld/GreetingController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/java/helloworld/GreetingController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/java/helloworld/InherTst.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/java/helloworld/InherTst.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/dependency-test/src/main/webapp/index.jsp
@@ -1,16 +1,15 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
-
 <%
    response.sendRedirect("spring/hello");
 %>

--- a/selenium/che-selenium-test/src/test/resources/projects/formatter/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/formatter/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/java/helloworld/GreetingController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/java/helloworld/GreetingController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/formatter/src/main/webapp/index.jsp
@@ -1,16 +1,15 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
-
 <%
    response.sendRedirect("spring/hello");
 %>

--- a/selenium/che-selenium-test/src/test/resources/projects/guess-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/guess-project/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/guess-project/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-lib/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-lib/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-lib/src/main/java/hello/SayHello.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-lib/src/main/java/hello/SayHello.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package hello;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-lib/src/test/java/hello/SayHelloTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-lib/src/test/java/hello/SayHelloTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package hello;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/java/helloworld/GreetingController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/java/helloworld/GreetingController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/my-webapp/src/main/webapp/index.jsp
@@ -1,16 +1,15 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
-
 <%
    response.sendRedirect("spring/hello");
 %>

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule-for-navigate/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-lib/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-lib/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-lib/src/main/java/hello/SayHello.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-lib/src/main/java/hello/SayHello.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package hello;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-lib/src/test/java/hello/SayHelloTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-lib/src/test/java/hello/SayHelloTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package hello;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/java/che/eclipse/sample/Aclass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/java/che/eclipse/sample/Aclass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package che.eclipse.sample;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/my-webapp/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-multimodule/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-commands/src/base/test/Aklass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-commands/src/base/test/Aklass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package base.test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-commands/src/com/company/nba/MainClass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-commands/src/com/company/nba/MainClass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.company.nba;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/.codenvy/misc.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/.codenvy/misc.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/new_folder/folder_2/file.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/new_folder/folder_2/file.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/new_folder/folder_3/file.css
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/new_folder/folder_3/file.css
@@ -1,11 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8";

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/new_folder/folder_4/file.html
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/new_folder/folder_4/file.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE html>

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/SayHello.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/SayHello.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package hello;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/pack_2/file.less
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/pack_2/file.less
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8"
 ;

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/pack_3/file.js
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/pack_3/file.js
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/pack_4/JavaClass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/main/java/hello/pack_4/JavaClass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package hello.pack_4;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/SayHelloTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/SayHelloTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package hello;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.css
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.css
@@ -1,11 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8";

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.html
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE html>

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.js
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.js
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.less
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.less
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8"
 ;

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.sql
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.sql
@@ -1,11 +1,11 @@
 --
--- Copyright (c) 2012-2017 Codenvy, S.A.
+-- Copyright (c) 2012-2017 Red Hat, Inc.
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0
 -- which accompanies this distribution, and is available at
 -- http://www.eclipse.org/legal/epl-v10.html
 --
 -- Contributors:
---   Codenvy, S.A. - initial API and implementation
+--   Red Hat, Inc. - initial API and implementation
 --
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-lib/src/test/java/hello/file.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/.codenvy/misc.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/.codenvy/misc.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.html
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE html>

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.js
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.js
@@ -1,11 +1,10 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
-

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.less
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.less
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 @CHARSET "UTF-8"
 ;

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.sql
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.sql
@@ -1,11 +1,11 @@
 --
--- Copyright (c) 2012-2017 Codenvy, S.A.
+-- Copyright (c) 2012-2017 Red Hat, Inc.
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0
 -- which accompanies this distribution, and is available at
 -- http://www.eclipse.org/legal/epl-v10.html
 --
 -- Contributors:
---   Codenvy, S.A. - initial API and implementation
+--   Red Hat, Inc. - initial API and implementation
 --
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/file.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
+-->
 -->

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/JavaClass_1.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/JavaClass_1.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/JavaClass_2.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/JavaClass_2.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/JavaClass_3.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/java/helloworld/JavaClass_3.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package helloworld;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/my-webapp/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-for-multiselect/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/java-project-with-additional-source-folder/src/Main.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/java-project-with-additional-source-folder/src/Main.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 public class Main {
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/java/lang/reflect/Klass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/java/lang/reflect/Klass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package java.lang.reflect;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A0.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A0.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 /**

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A1.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A1.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 class A1{

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A17.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A17.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update
 package r;

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A2.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A2.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 public class A2 {

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A5.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A5.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 public class A5 {

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A6.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A6.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 // no update of textual match to r and "r"
 package r;

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A7.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A7.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A9.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/A9.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/B2.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/B2.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/fred2/B2.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/fred2/B2.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.fred2;
 import r.*;

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/fred3/B3.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/fred3/B3.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.fred3;
 import r.r.*;

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/r/A3.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/r/A3.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.r;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/r/r/A4.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/java/r/r/r/A4.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r.r.r;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/test/java/r/A12.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/move-items-project/src/test/java/r/A12.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package r;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/src/main/java/multimodule/App.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/src/main/java/multimodule/App.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package multimodule;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/src/main/resources/logback.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/src/main/resources/logback.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <configuration>

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/model/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/model/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/model/src/main/java/multimodule/model/Book.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/model/src/main/java/multimodule/model/Book.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package multimodule.model;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/model/src/main/java/multimodule/model/BookImpl.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/model/src/main/java/multimodule/model/BookImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package multimodule.model;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/node-js-simple/app.js
+++ b/selenium/che-selenium-test/src/test/resources/projects/node-js-simple/app.js
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
 var greetings = require("./greetings.js");
 var b = greetings.sayHelloInEnglish();

--- a/selenium/che-selenium-test/src/test/resources/projects/node-js-simple/greetings.js
+++ b/selenium/che-selenium-test/src/test/resources/projects/node-js-simple/greetings.js
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
 module.exports   = {
   sayHelloInEnglish: function() {

--- a/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/not-formated-project/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/plain-java-project/src/com/company/nba/ATest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plain-java-project/src/com/company/nba/ATest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.company.nba;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plain-java-project/src/com/company/nba/MainClass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plain-java-project/src/com/company/nba/MainClass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.company.nba;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/cpp-tests/hello.cc
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/cpp-tests/hello.cc
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 // Simple Hello World
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-inner-lambda/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-inner-lambda/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-inner-lambda/src/main/java/test/App.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-inner-lambda/src/main/java/test/App.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-inner-lambda/src/test/java/test/AppTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-inner-lambda/src/test/java/test/AppTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/app/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/app/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/app/src/main/java/multimodule/App.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/app/src/main/java/multimodule/App.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package multimodule;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/model/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/model/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/model/src/main/java/multimodule/model/Book.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/model/src/main/java/multimodule/model/Book.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package multimodule.model;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/model/src/main/java/multimodule/model/BookImpl.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/model/src/main/java/multimodule/model/BookImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package multimodule.model;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-multimodule/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/src/main/java/org/eclipse/che/examples/SimpleLogger.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/src/main/java/org/eclipse/che/examples/SimpleLogger.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/src/main/resources/log4j.properties
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/src/main/resources/log4j.properties
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2012-2017 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 
 log4j.rootLogger=DEBUG, stdout

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/src/main/resources/logback.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/java-with-external-libs/src/main/resources/logback.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <configuration>

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/php-tests/index.php
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/php-tests/index.php
@@ -1,14 +1,24 @@
 <?php include 'lib.php';?>
-<?php
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
+ */
+<?php
+/*
+ * Copyright (c) 2012-2017 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
  */
 
 echo sayHello("man");

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/php-tests/lib.php
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/DebuggerPlugin/php-tests/lib.php
@@ -1,15 +1,14 @@
 <?php
 /*
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  */
-
 function sayHello($name) {
     return "Hello, " + $name;
 }

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/main/java/org/eclipse/che/examples/HelloWorld.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/main/java/org/eclipse/che/examples/HelloWorld.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/test/java/org/eclipse/che/examples/AppAnotherTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/test/java/org/eclipse/che/examples/AppAnotherTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/test/java/org/eclipse/che/examples/AppOneTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/test/java/org/eclipse/che/examples/AppOneTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/test/java/org/eclipse/che/examples/Junit4TestSuite.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/junit4-tests/src/test/java/org/eclipse/che/examples/Junit4TestSuite.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/main/java/org/eclipse/che/examples/HelloWorld.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/main/java/org/eclipse/che/examples/HelloWorld.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/test/java/org/eclipse/che/examples/AppAnotherTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/test/java/org/eclipse/che/examples/AppAnotherTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/test/java/org/eclipse/che/examples/AppOneTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/test/java/org/eclipse/che/examples/AppOneTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/test/resources/testng.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/plugins/JavaTestRunnerPlugin/testng-tests/src/test/resources/testng.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Company.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Company.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Empl.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Empl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Employee.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Employee.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/EmployeeFixedSalary.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/EmployeeFixedSalary.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/EmployeeHourlyWages.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/EmployeeHourlyWages.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Initializer.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/Initializer.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/InvalidArgumentException.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/InvalidArgumentException.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortDate.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortDate.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortId.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortId.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortSalary.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortSalary.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortSurname.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/prOutline/src/main/java/com/codenvy/qa/SortSurname.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.qa;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test0;
 /**

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test1;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test10/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test10/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test10;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test2;
 interface A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test24/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test24/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test24;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test25/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test25/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test25;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test26/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test26/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test26;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test28/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test28/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test28;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3;
 /**

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test31/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test31/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test31;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test32/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test32/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test32;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test33/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test33/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test33;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test36/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test36/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test36;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test36/messages.properties
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test36/messages.properties
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2012-2017 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 
 f=a

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test37/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test37/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test37;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test37/B.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test37/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test37;
 import static test19.A.PI;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test37/C.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test37/C.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test37;
 import static test37.A.*;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test5;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test6/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test6/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test6;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test8/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test8/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test8;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test9/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/test9/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test9;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail10/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail10/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail10;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail14/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail14/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail14;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail3;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-non-private-field/src/main/java/testfail7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/java/lang/reflect/Klass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/java/lang/reflect/Klass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package java.lang.reflect;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/m_y/pack/C.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/m_y/pack/C.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package m_y.pack;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my/MyA.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my/MyA.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package my;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my/a/ATest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my/a/ATest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package my.a;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my/b/B.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my/b/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package my.b;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my_/pack/C.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/my_/pack/C.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package my_.pack;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test0/r/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test0/r/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test0.r;
 /**

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test1/r/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test1/r/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test1.r;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test2/fred/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test2/fred/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test2.fred;
 import test2.r.*;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test2/r/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test2/r/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test2.r;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test3/fred/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test3/fred/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3.fred;
 import test3.r.r.*;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test3/r/r/B.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test3/r/r/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3.r.r;
 public class B {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test4/r/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test4/r/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4.r;
  class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test4/r/p1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test4/r/p1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4.r.p1;
 public class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test5/r/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test5/r/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update
 package test5.r;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test6/r/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test6/r/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update but update of textual match to test6.r and "test6.r"
 package test6.r;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test7/r/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test7/r/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7.r;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test7/r/s/B.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/java/test7/r/s/B.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7.r.s;
 public class B {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-package/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j
 package test0;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test12/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test12/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to j
 package test12;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test15/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test15/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j, i
 package test15;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test18/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test18/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test18;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test21/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test21/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test21;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test25/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test25/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test25;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test28/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test28/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to: j
 package test28;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to: j, j1
 package test3;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test31/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test31/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to kk, j
 package test31;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test33/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test33/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //renaming to b, no ref update
 package test33;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test36/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test36/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test36;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test6/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test6/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to k
 package test6;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test9/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/test9/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //rename to j
 package test9;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail11/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail11/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j, j
 package testfail11;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail14/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail14/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to j
 package testfail14;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail17/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail17/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j
 package testfail17;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to i, i
 package testfail2;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail20/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail20/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j
 package testfail20;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: i, 9
 package testfail3;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-parameters/src/main/java/testfail7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //cannot rename to: j
 package testfail7;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test1/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test1/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test1;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test10/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test10/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test10;
 import java.util.List;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test11/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test11/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test11;
 import Test.Element;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test12/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test12/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test12;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test2/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test2/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //no ref update
 package test2;

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test3/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test3/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test3;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test4;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test5/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test5/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test5;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test6/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test6/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test6;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test7;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test8/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test8/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test8;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test9/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/test9/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test9;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail0/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail0/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail0;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail4/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail4/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail4;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail6/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail6/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail6;
 class A {

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail7/A.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/java/testfail7/A.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package testfail7;
 class A{

--- a/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/rename-private-field/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0087/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0087/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0087/src/main/java/org/eclipse/qa/examples/Myclass0087.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0087/src/main/java/org/eclipse/qa/examples/Myclass0087.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0087/src/main/java/test/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0087/src/main/java/test/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test;
 import static org.eclipse.qa.examples.Myclass0087.bar;

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/pom.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/src/main/java/test/MyAnnot.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/src/main/java/test/MyAnnot.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/src/main/java/test/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/src/main/java/test/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package test;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/src/test/java/resolveTests_1_5_t0091/AppTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0091/src/test/java/resolveTests_1_5_t0091/AppTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package resolveTests_1_5_t0091;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0093/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0093/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0093/src/main/java/org/eclipse/qa/examples/MyEnum.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0093/src/main/java/org/eclipse/qa/examples/MyEnum.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0093/src/main/java/org/eclipse/qa/examples/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0093/src/main/java/org/eclipse/qa/examples/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 import java.util.List;

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0097/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0097/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0097/src/main/java/org/eclipse/qa/examples/Key.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0097/src/main/java/org/eclipse/qa/examples/Key.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0097/src/main/java/org/eclipse/qa/examples/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0097/src/main/java/org/eclipse/qa/examples/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0114/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0114/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0114/src/main/java/org/eclipse/qa/examples/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0114/src/main/java/org/eclipse/qa/examples/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0114/src/main/java/org/eclipse/qa/examples/Test2.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0114/src/main/java/org/eclipse/qa/examples/Test2.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 import java.util.List;

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0115/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0115/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0115/src/main/java/org/eclipse/qa/examples/X.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0115/src/main/java/org/eclipse/qa/examples/X.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/src/main/java/org/eclipse/qa/examples/Collections.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/src/main/java/org/eclipse/qa/examples/Collections.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/src/main/java/org/eclipse/qa/examples/List.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/src/main/java/org/eclipse/qa/examples/List.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/src/main/java/org/eclipse/qa/examples/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0119/src/main/java/org/eclipse/qa/examples/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/src/main/java/org/eclipse/qa/examples/Collections.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/src/main/java/org/eclipse/qa/examples/Collections.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/src/main/java/org/eclipse/qa/examples/List.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/src/main/java/org/eclipse/qa/examples/List.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/src/main/java/org/eclipse/qa/examples/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0120/src/main/java/org/eclipse/qa/examples/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/src/main/java/org/eclipse/qa/examples/Collections.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/src/main/java/org/eclipse/qa/examples/Collections.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/src/main/java/org/eclipse/qa/examples/List.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/src/main/java/org/eclipse/qa/examples/List.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/src/main/java/org/eclipse/qa/examples/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0121/src/main/java/org/eclipse/qa/examples/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0122/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0122/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0122/src/main/java/org/eclipse/qa/examples/Test.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/resolveTests_1_5_t0122/src/main/java/org/eclipse/qa/examples/Test.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/java/com/codenvy/example/spring/GreetingController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/java/com/codenvy/example/spring/GreetingController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.spring;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/java/com/codenvy/example/spring/TestClass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/java/com/codenvy/example/spring/TestClass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.spring;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/show-hints-project/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/simple-java-project/src/com/company/Main.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/simple-java-project/src/com/company/Main.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.company;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/simple_Artik_project/test.c
+++ b/selenium/che-selenium-test/src/test/resources/projects/simple_Artik_project/test.c
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 #include <stdio.h>
 

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/java/org/eclipse/qa/examples/HintTestClass.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/java/org/eclipse/qa/examples/HintTestClass.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-for-hint-test/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-for-file-watcher-tabs/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/java/org/eclipse/qa/examples/AppController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/java/org/eclipse/qa/examples/AppController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/java/org/eclipse/qa/examples/HelloWorld.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/java/org/eclipse/qa/examples/HelloWorld.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.qa.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/WEB-INF/jsp/guess_num.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/WEB-INF/jsp/guess_num.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/java/org/eclipse/che/examples/GreetingController.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/java/org/eclipse/che/examples/GreetingController.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package org.eclipse.che.examples;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/WEB-INF/web.xml
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app PUBLIC

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-target/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <%

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/newFile.css
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/newFile.css
@@ -1,10 +1,10 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/FetchUpdatesAndMergeRemoteBranchIntoLocalTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/FetchUpdatesAndMergeRemoteBranchIntoLocalTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //1418332213859_change_content
 

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/GitPullTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/GitPullTest.java
@@ -1,11 +1,11 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //first change 1409772229684

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/JavaCommentsTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/JavaCommentsTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //first_change1418333979848
 

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/PushingChangesTest.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/java/commenttest/PushingChangesTest.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 //1409274557295_<!--change content-->
 

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/webapp/WEB-INF/jsp/hello_view.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/webapp/WEB-INF/jsp/hello_view.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 <html>

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='utf-8'?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">

--- a/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/webapp/index.jsp
+++ b/selenium/che-selenium-test/src/test/resources/projects/testRepo-1/src/main/webapp/index.jsp
@@ -1,13 +1,13 @@
 <%--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 --%>
 1409274557295_<!--change content-->

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/pom.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <project

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/client/GWTEntryPoint.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/client/GWTEntryPoint.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.gwt.client;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/client/GreetingService.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/client/GreetingService.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.gwt.client;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/server/GreetingServiceImpl.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/server/GreetingServiceImpl.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.gwt.server;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/shared/FieldVerifier.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/java/com/codenvy/example/gwt/shared/FieldVerifier.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 package com.codenvy.example.gwt.shared;
 

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/resources/com/codenvy/example/gwt/GWT.gwt.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/resources/com/codenvy/example/gwt/GWT.gwt.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <module rename-to='GWT'>

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/resources/com/codenvy/example/gwt/client/Messages.properties
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/resources/com/codenvy/example/gwt/client/Messages.properties
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2012-2017 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 
 sendButton = Send

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/resources/com/codenvy/example/gwt/client/Messages_fr.properties
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/resources/com/codenvy/example/gwt/client/Messages_fr.properties
@@ -1,12 +1,12 @@
 #
-# Copyright (c) 2012-2017 Codenvy, S.A.
+# Copyright (c) 2012-2017 Red Hat, Inc.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 #
 # Contributors:
-#   Codenvy, S.A. - initial API and implementation
+#   Red Hat, Inc. - initial API and implementation
 #
 
 sendButton = Envoyer

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/webapp/GWT.css
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/webapp/GWT.css
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2012-2017 Codenvy, S.A.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *   Codenvy, S.A. - initial API and implementation
+ *   Red Hat, Inc. - initial API and implementation
  *******************************************************************************/
 /** Add css rules here for your application. */
 

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/webapp/GWT.html
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/webapp/GWT.html
@@ -1,13 +1,13 @@
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!doctype html>

--- a/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/webapp/WEB-INF/web.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/web-gwt-java-simple/src/main/webapp/WEB-INF/web.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012-2017 Codenvy, S.A.
+    Copyright (c) 2012-2017 Red Hat, Inc.
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
     which accompanies this distribution, and is available at
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-      Codenvy, S.A. - initial API and implementation
+      Red Hat, Inc. - initial API and implementation
 
 -->
 <!DOCTYPE web-app


### PR DESCRIPTION
### What does this PR do?
This request replaces _"Codenvy, S.A."_ on _"Red Hat, Inc."_ in copyright headers of selenium test resources. 
Also, it turns on checking on headers in files of resource directory of tests.

@tolusha: please, review this request.